### PR TITLE
CORE-1455: Add some policy file templates

### DIFF
--- a/templates/policy/Commands/PantheonAliasPolicyCommands.php
+++ b/templates/policy/Commands/PantheonAliasPolicyCommands.php
@@ -1,0 +1,59 @@
+<?php
+namespace Drush\Commands;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
+use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Put this file in $HOME/.drush/pantheon/Commands/PantheonPolicyCommands.php
+ * and load it via:
+ *
+ *     drush --include=$HOME/.drush/pantheon
+ *
+ * Alternately, add the path to $HOME/.drush/drush.yml:
+ *
+ *     drush:
+ *       paths:
+ *         include:
+ *           - '${env.home}/.drush/pantheon'
+ */
+
+class PantheonAliasPolicyCommands extends DrushCommands implements SiteAliasManagerAwareInterface
+{
+    use SiteAliasManagerAwareTrait;
+
+    /**
+     * Check to see if the current alias is a Pantheon alias. If so, we will
+     * validate whether or not the
+     *
+     * @hook pre-init *
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Consolidation\AnnotatedCommand\AnnotationData $annotationData
+     */
+    public function alter(InputInterface $input, AnnotationData $annotationData)
+    {
+        $self = $this->siteAliasManager()->getSelf();
+        if ($self->isRemote()) {
+            $host = $self->get('host');
+            // @todo: Only do this check if the host begins with 'appserver.'
+            // and ends in '.drush.in'.
+            $ip = gethostbyname($host);
+
+            // If the return value of gethostbyname equals its input parameter,
+            // that indicates failure.
+            if ($host == $ip) {
+                $aliasName = $self->name();
+                // @todo: Convert 'appserver.*.' to 'appserver.dev.' and check
+                // again. If that works, give the error message below. If it
+                // fails, then report that the site does not exist.
+                throw new \Exception("The alias $aliasName refers to a multidev environment that does not exist.");
+            }
+        }
+    }
+}

--- a/templates/policy/Commands/PantheonAliasPolicyCommands.php
+++ b/templates/policy/Commands/PantheonAliasPolicyCommands.php
@@ -49,9 +49,6 @@ class PantheonAliasPolicyCommands extends DrushCommands implements SiteAliasMana
             // that indicates failure.
             if ($host == $ip) {
                 $aliasName = $self->name();
-                // @todo: Convert 'appserver.*.' to 'appserver.dev.' and check
-                // again. If that works, give the error message below. If it
-                // fails, then report that the site does not exist.
                 throw new \Exception("The alias $aliasName refers to a multidev environment that does not exist.");
             }
         }

--- a/templates/policy/drush8/pantheon_policy.drush.inc
+++ b/templates/policy/drush8/pantheon_policy.drush.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Adjust the contents of a site alias.
+ */
+function pantheon_policy_drush_sitealias_alter(&$alias_record) {
+  // If the alias is "remote", but the remote site is
+  // the system this command is running on, convert the
+  // alias record to a local alias.
+  if (isset($alias_record['remote-host'])) {
+    $host = $alias_record['remote-host'];
+    // @todo: Only do this check if the host begins with 'appserver.'
+    // and ends in '.drush.in'.
+    $ip = gethostbyname($host);
+    // If the return value of gethostbyname equals its input parameter,
+    // that indicates failure.
+    if ($host == $ip) {
+      $aliasName = $alias_record['#name'];
+      // @todo: Convert 'appserver.*.' to 'appserver.dev.' and check
+      // again. If that works, give the error message below. If it
+      // fails, then report that the site does not exist.
+      return drush_set_error('NO_SUCH_ALIAS', "The alias $aliasName refers to a multidev environment that does not exist.");
+    }
+  }
+}

--- a/templates/policy/drush8/pantheon_policy.drush.inc
+++ b/templates/policy/drush8/pantheon_policy.drush.inc
@@ -16,9 +16,6 @@ function pantheon_policy_drush_sitealias_alter(&$alias_record) {
     // that indicates failure.
     if ($host == $ip) {
       $aliasName = $alias_record['#name'];
-      // @todo: Convert 'appserver.*.' to 'appserver.dev.' and check
-      // again. If that works, give the error message below. If it
-      // fails, then report that the site does not exist.
       return drush_set_error('NO_SUCH_ALIAS', "The alias $aliasName refers to a multidev environment that does not exist.");
     }
   }


### PR DESCRIPTION
To enable these:

Drush 9 ~/.drush/drush.yml:
```
drush:
  paths:
    include:
      - '${env.home}/.drush/pantheon'
```

Drush 8 ~/.drush/drushrc.php:
```
<?php
$options['include'][] = drush_server_home() . '/.drush/pantheon/drush8';
```
