### PR TITLE
Get rid of legacy 'drush9' command

### DIFF
--- a/templates/fragment.site.yml.tmpl
+++ b/templates/fragment.site.yml.tmpl
@@ -5,7 +5,7 @@
 ##  db-url: 'mysql://pantheon:{{db_password}}@dbserver.{{env_label}}.{{site_id}}.drush.in:{{db_port}}/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: {{env_label}}-{{site_name}}.pantheonsite.io
   user: {{env_label}}.{{site_id}}
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/agency.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/agency.site.yml
@@ -5,7 +5,7 @@
     db-url: 'mysql://pantheon:00000000000000000000000000000000@dbserver.live.00000000-0000-0000-0000-000000000000.drush.in:00000/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-agency.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -20,7 +20,7 @@
     db-url: 'mysql://pantheon:11111111111111111111111111111111@dbserver.test.11111111-1111-1111-1111-111111111111.drush.in:11111/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-agency.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -35,7 +35,7 @@
     db-url: 'mysql://pantheon:22222222222222222222222222222222@dbserver.dev.22222222-2222-2222-2222-222222222222.drush.in:22222/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-agency.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:
@@ -50,7 +50,7 @@
     db-url: 'mysql://pantheon:33333333333333333333333333333333@dbserver.feature8.33333333-3333-3333-3333-333333333333.drush.in:33333/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature8-agency.pantheonsite.io
   user: feature8.33333333-3333-3333-3333-333333333333
   ssh:
@@ -65,7 +65,7 @@
     db-url: 'mysql://pantheon:44444444444444444444444444444444@dbserver.feature24.44444444-4444-4444-4444-444444444444.drush.in:44444/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature24-agency.pantheonsite.io
   user: feature24.44444444-4444-4444-4444-444444444444
   ssh:
@@ -80,7 +80,7 @@
     db-url: 'mysql://pantheon:55555555555555555555555555555555@dbserver.feature101.55555555-5555-5555-5555-555555555555.drush.in:55555/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature101-agency.pantheonsite.io
   user: feature101.55555555-5555-5555-5555-555555555555
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/demo.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/demo.site.yml
@@ -5,7 +5,7 @@
     db-url: 'mysql://pantheon:00000000000000000000000000000000@dbserver.live.00000000-0000-0000-0000-000000000000.drush.in:00000/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-demo.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -20,7 +20,7 @@
     db-url: 'mysql://pantheon:11111111111111111111111111111111@dbserver.test.11111111-1111-1111-1111-111111111111.drush.in:11111/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-demo.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -35,7 +35,7 @@
     db-url: 'mysql://pantheon:22222222222222222222222222222222@dbserver.dev.22222222-2222-2222-2222-222222222222.drush.in:22222/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-demo.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:
@@ -50,7 +50,7 @@
     db-url: 'mysql://pantheon:33333333333333333333333333333333@dbserver.multidev.33333333-3333-3333-3333-333333333333.drush.in:33333/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: multidev-demo.pantheonsite.io
   user: multidev.33333333-3333-3333-3333-333333333333
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/personalsite.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithDbUrl/sites/pantheon/personalsite.site.yml
@@ -5,7 +5,7 @@
     db-url: 'mysql://pantheon:00000000000000000000000000000000@dbserver.live.00000000-0000-0000-0000-000000000000.drush.in:00000/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-personalsite.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -20,7 +20,7 @@
     db-url: 'mysql://pantheon:11111111111111111111111111111111@dbserver.test.11111111-1111-1111-1111-111111111111.drush.in:11111/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-personalsite.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -35,7 +35,7 @@
     db-url: 'mysql://pantheon:22222222222222222222222222222222@dbserver.dev.22222222-2222-2222-2222-222222222222.drush.in:22222/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-personalsite.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/agency.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/agency.site.yml
@@ -2,7 +2,7 @@
   host: appserver.live.00000000-0000-0000-0000-000000000000.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-agency.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -14,7 +14,7 @@
   host: appserver.test.11111111-1111-1111-1111-111111111111.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-agency.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -26,7 +26,7 @@
   host: appserver.dev.22222222-2222-2222-2222-222222222222.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-agency.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:
@@ -38,7 +38,7 @@
   host: appserver.feature8.33333333-3333-3333-3333-333333333333.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature8-agency.pantheonsite.io
   user: feature8.33333333-3333-3333-3333-333333333333
   ssh:
@@ -50,7 +50,7 @@
   host: appserver.feature24.44444444-4444-4444-4444-444444444444.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature24-agency.pantheonsite.io
   user: feature24.44444444-4444-4444-4444-444444444444
   ssh:
@@ -62,7 +62,7 @@
   host: appserver.feature101.55555555-5555-5555-5555-555555555555.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: feature101-agency.pantheonsite.io
   user: feature101.55555555-5555-5555-5555-555555555555
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/demo.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/demo.site.yml
@@ -2,7 +2,7 @@
   host: appserver.live.00000000-0000-0000-0000-000000000000.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-demo.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -14,7 +14,7 @@
   host: appserver.test.11111111-1111-1111-1111-111111111111.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-demo.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -26,7 +26,7 @@
   host: appserver.dev.22222222-2222-2222-2222-222222222222.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-demo.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:
@@ -38,7 +38,7 @@
   host: appserver.multidev.33333333-3333-3333-3333-333333333333.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: multidev-demo.pantheonsite.io
   user: multidev.33333333-3333-3333-3333-333333333333
   ssh:

--- a/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/personalsite.site.yml
+++ b/tests/fixtures/sitesYmlEmitter/standardWithoutDbUrl/sites/pantheon/personalsite.site.yml
@@ -2,7 +2,7 @@
   host: appserver.live.00000000-0000-0000-0000-000000000000.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: live-personalsite.pantheonsite.io
   user: live.00000000-0000-0000-0000-000000000000
   ssh:
@@ -14,7 +14,7 @@
   host: appserver.test.11111111-1111-1111-1111-111111111111.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: test-personalsite.pantheonsite.io
   user: test.11111111-1111-1111-1111-111111111111
   ssh:
@@ -26,7 +26,7 @@
   host: appserver.dev.22222222-2222-2222-2222-222222222222.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: dev-personalsite.pantheonsite.io
   user: dev.22222222-2222-2222-2222-222222222222
   ssh:

--- a/tests/unit/TemplateTest.php
+++ b/tests/unit/TemplateTest.php
@@ -28,7 +28,7 @@ class TemplateTest extends TestCase
   host: appserver.MULTIDEV.00000000-0000-0000-0000-000000000000.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: MULTIDEV-MYSITE.pantheonsite.io
   user: MULTIDEV.00000000-0000-0000-0000-000000000000
   ssh:
@@ -44,7 +44,7 @@ EOT;
     db-url: 'mysql://pantheon:SECRETSECRET@dbserver.MULTIDEV.00000000-0000-0000-0000-000000000000.drush.in:10101/pantheon'
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: MULTIDEV-MYSITE.pantheonsite.io
   user: MULTIDEV.00000000-0000-0000-0000-000000000000
   ssh:


### PR DESCRIPTION
First attempt to address https://github.com/pantheon-systems/terminus-aliases-plugin/issues/15